### PR TITLE
Issues 4, 5, and add `da00`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ConfigArgParse == 1.5.3
 confluent-kafka >= 2.1.1
-ess-streaming-data-types >= 0.21.0
+ess-streaming-data-types >= 0.26.1
 PyQt5 >= 5.14.1

--- a/wherefore.py
+++ b/wherefore.py
@@ -13,7 +13,7 @@ from typing import Tuple, Optional, Union, List, Dict
 
 
 def extract_point(point: str) -> Tuple[Union[datetime, int, str], Optional[int]]:
-    match = re.match("(?P<timestamp>\d+)s(?P<offset>[+-]\d+)?$", point)
+    match = re.match(r"(?P<timestamp>\d+)s(?P<offset>[+-]\d+)?$", point)
     if match is not None:
         offset_int = None
         if match["offset"] is not None:
@@ -23,7 +23,7 @@ def extract_point(point: str) -> Tuple[Union[datetime, int, str], Optional[int]]
             offset_int,
         )
     match = re.match(
-        "(?P<offset_str>(?:never)|(?:end)|(?:beginning))(?P<offset>[+-]\d+)?$", point
+        r"(?P<offset_str>(?:never)|(?:end)|(?:beginning))(?P<offset>[+-]\d+)?$", point
     )
     if match is not None:
         offset_int = None
@@ -34,13 +34,13 @@ def extract_point(point: str) -> Tuple[Union[datetime, int, str], Optional[int]]
             "beginning": PartitionOffset.BEGINNING,
             "never": PartitionOffset.NEVER,
         }[match["offset_str"]], offset_int
-    match = re.match("(?P<offset_int>\d+)(?P<offset_to_offset>[+-]\d+)?$", point)
+    match = re.match(r"(?P<offset_int>\d+)(?P<offset_to_offset>[+-]\d+)?$", point)
     if match is not None:
         return_int = int(match["offset_int"])
         if match["offset_to_offset"] is not None:
             return_int += int(match["offset_to_offset"])
         return return_int, None
-    match = re.match("^(?P<datetime>.+?)(?P<offset>[+-]\d+)?$", point)
+    match = re.match(r"^(?P<datetime>.+?)(?P<offset>[+-]\d+)?$", point)
     try:
         offset_int = None
         if match["offset"] is not None:

--- a/wherefore/Message.py
+++ b/wherefore/Message.py
@@ -280,7 +280,8 @@ def se00_extractor(data: bytes) -> Tuple[str, Optional[datetime], str]:
         f"Nr of elements: {len(message.values)}",
     )
 
-def da00_extractor(data: bytes) -> Tuple[str, datetime | None, str]:
+
+def da00_extractor(data: bytes) -> Tuple[str, Optional[datetime], str]:
     message = deserialise_da00(data)
     return (
         message.source_name,
@@ -318,7 +319,7 @@ TYPE_EXTRACTOR_MAP = {
 
 
 def unknown_extractor(name: str):
-    def named_extractor(data: bytes) -> Tuple[str, datetime | None, str]:
+    def named_extractor(data: bytes) -> Tuple[str, Optional[datetime], str]:
         return f"Unknown {name} source", None, f"No extractor for {name} (yet)"
 
     return named_extractor

--- a/wherefore/Message.py
+++ b/wherefore/Message.py
@@ -24,6 +24,7 @@ from streaming_data_types import (
     deserialise_tdct,
     deserialise_wrdn,
     deserialise_x5f2,
+    deserialise_da00,
 )
 from wherefore.MonitorMessage import MonitorMessage
 from datetime import datetime, timezone
@@ -279,6 +280,14 @@ def se00_extractor(data: bytes) -> Tuple[str, Optional[datetime], str]:
         f"Nr of elements: {len(message.values)}",
     )
 
+def da00_extractor(data: bytes) -> Tuple[str, datetime | None, str]:
+    message = deserialise_da00(data)
+    return (
+        message.source_name,
+        datetime.fromtimestamp(message.timestamp_ns / 1e9, tz=timezone.utc),
+        f"{len(message.data)} Variables: {','.join(x.name for x in message.data)}",
+    )
+
 
 TYPE_EXTRACTOR_MAP = {
     "6s4t": s_6s4t_extractor,
@@ -304,17 +313,22 @@ TYPE_EXTRACTOR_MAP = {
     "f144": f144_extractor,
     "se00": se00_extractor,
     "al00": al00_extractor,
+    "da00": da00_extractor,
 }
+
+
+def unknown_extractor(name: str):
+    def named_extractor(data: bytes) -> Tuple[str, datetime | None, str]:
+        return f"Unknown {name} source", None, f"No extractor for {name} (yet)"
+
+    return named_extractor
 
 
 def extract_message_info(message_data: bytes) -> Tuple[str, str, datetime, str]:
     message_type = get_schema(
         message_data
     )  # TODO add error handling for messages too short
-    try:
-        extractor = TYPE_EXTRACTOR_MAP[message_type]
-    except KeyError:
-        return "Unknown", "Unknown", None, "No data"
+    extractor = TYPE_EXTRACTOR_MAP.get(message_type, unknown_extractor(message_type))
     try:
         source, timestamp, display_message = extractor(message_data)
         source = "".join(letter for letter in source if letter in string.printable)


### PR DESCRIPTION
Fixes issue #4 by changing regex strings with illegal escape characters into raw strings.

Fixes issue #5 by adding an 'extractor' for unknown streaming data types that reports its name such that, e.g., `ar51` messages are identified when examining their topic.

Adds an extractor for `da00`.